### PR TITLE
Change array size in notebook

### DIFF
--- a/content/mechaphlowers_basics.ipynb
+++ b/content/mechaphlowers_basics.ipynb
@@ -310,7 +310,7 @@
       },
       "outputs": [],
       "source": [
-        "cable_data = pd.DataFrame(\n",
+        "cable_array = CableArray(pd.DataFrame(\n",
         "\t\t{\n",
         "\t\t\t\"section\": [345.55],\n",
         "\t\t\t\"diameter\": [22.4],\n",
@@ -320,7 +320,7 @@
         "\t\t\t\"temperature_reference\": [0],\n",
         "\t\t}\n",
         "\t)\n",
-        "cable_array = CableArray(cable_data.loc[cable_data.index.repeat(4)].reset_index(drop=True))\n",
+        ")\n",
         "cable_array.data"
       ]
     },


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
The PR: https://github.com/phlowers/mechaphlowers/pull/170 in mechaphlowers change the CableArray size that is needed from [number of spans] to 1.
This PR update the example notebook to apply these changes: the CableArray given as an example only has one row


**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Other information**:
Should be merged after this PR on mechaphlowers:
https://github.com/phlowers/mechaphlowers/pull/170